### PR TITLE
add house_supporters and senate_supporters to ExternalCountFetcher

### DIFF
--- a/app/models/legislator.rb
+++ b/app/models/legislator.rb
@@ -17,6 +17,7 @@ class Legislator < ActiveRecord::Base
   scope :targeted,     -> { joins(:campaigns).merge(Campaign.active) }
   scope :top_priority, -> { targeted.merge(Target.top_priority) }
   scope :unconvinced,  -> { where(with_us: false) }
+  scope :with_us,      -> { where(with_us: true) }
 
   attr_accessor :district_code, :state_abbrev
   before_validation :assign_district, :assign_state

--- a/lib/external_count_fetcher.rb
+++ b/lib/external_count_fetcher.rb
@@ -53,8 +53,8 @@
         when :donations_total     then Integration::PledgeService.donations_total
         when :called_voters_count then 0
         when :reps_calls_count    then 0
-        when :house_supporters    then 0
-        when :senate_supporters   then 0
+        when :house_supporters    then Legislator.house.with_us.count
+        when :senate_supporters   then Legislator.senate.with_us.count
         else raise ArgumentError, "Unknown Key: #{key}"
       end
       redis_counter(counter_key).value = count


### PR DESCRIPTION
not sure if this is how you wanted to handle it. Seemed like the easiest solution. I actually did this differently the first time I tried, but then thought it might be good to cache these counts in redis with all the other counts. Not like it's a difficult query for the db to fetch the count every time, but the supporter count will change so infrequently...

let me know if you want me to do this differently

Right now it's never running `Legislator.recheck_reps_with_us`, so we'll need to decide when we want that to run. I kinda thought we might start by running `Legislator.recheck_reps_with_us` manually and then set it to automatic if and when that seemed right