### PR TITLE
Adding Sidekiq monitoring, and also updating docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Set development environment variables here. Uses https://github.com/bkeepers/dotenv
 
 SIDEKIQ_TESTING=inline
+SIDEKIQ_DASHBOARD_PASSWORD=sidekiq
 
 SUNLIGHT_KEY=YOURKEY
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ If you want to use [Docker](https://www.docker.com/) for local development, this
 
 If you already have Docker and Docker Compose installed, starting this app is as easy as `docker-compose up`.
 
+After you've created the Docker containers, you can apply the migrations to the database with `docker-compose run web rake db:migrate`.
+
 ### RVM
 
 *If you don't want to use Docker* for some reason, you can also just install ruby and all dependencies on your own:
@@ -37,6 +39,19 @@ If you already have Docker and Docker Compose installed, starting this app is as
 1. Install Redis
 1. Install Posgres and set up a user account.
 1. Install gems w/ `bundle install`
+
+You will also need to start a local PostgreSQL database and a Redis instance.
+
+Finally, apply the database migrations with `rake db:migrate`.
+
+### Sidekiq worker
+
+This app uses [sidekiq](https://github.com/mperham/sidekiq) to do background processing for a few tasks.
+
+By default, the app expects a sidekiq worker process to be available. You can start this process locally by running `bundle exec sidekiq -c 10`.
+
+If you don't want to send jobs to sidekiq, you can set the `SIDEKIQ_TESTING` environment variable to `'inline'` or `'fake'`.
+
 
 Deployment & Hosting Environments
 ---------------------------------

--- a/config.ru
+++ b/config.ru
@@ -16,3 +16,18 @@ use Rack::Cors do
       :methods => [:get, :post, :put, :options]
   end
 end
+
+# Code to enable the sidekiq monitoring dashboard
+require 'sidekiq'
+Sidekiq.configure_client do |config|
+  config.redis = { :size => 1 }
+end
+
+require 'sidekiq/web'
+map '/sidekiq' do
+  use Rack::Auth::Basic, "Protected Area" do |username, password|
+    username == 'sidekiq' && password == ENV["SIDEKIQ_DASHBOARD_PASSWORD"]
+  end
+
+  run Sidekiq::Web
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,8 @@ Rails.application.routes.draw do
   get  '/calls/new_connection',           to: 'calls#new_connection'
   post '/calls/connection_gather_prompt', to: 'calls#connection_gather_prompt'
   post '/calls/connection_gather',        to: 'calls#connection_gather'
+
+  require 'sidekiq/api'
+  get "/queue-status" => proc { [200, {"Content-Type" => "text/plain"}, [Sidekiq::Queue.new.size < 100 ? "OK" : "UHOH" ]] }
+  get "/queue-latency" => proc { [200, {"Content-Type" => "text/plain"}, [Sidekiq::Queue.new.latency < 30 ? "OK" : "UHOH" ]] }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,19 @@ web:
     - DATABASE_URL=postgres://postgres@db:5432/postgres
     - REDIS_URL=redis://redis@redis:6379/
 
+worker:
+  image: mayday20backend_web:latest
+  command: bundle exec sidekiq -c 10
+  volumes:
+    - .:/usr/src/app
+  links:
+    - redis
+  env_file:
+    - .env
+  environment:
+    - REDIS_PROVIDER=REDIS_URL
+    - REDIS_URL=redis://redis@redis:6379/
+
 db:
   image: postgres:9.4
 


### PR DESCRIPTION
@Rio517 @turino - I spent a little time this afternoon working on our sidekiq monitoring.

I was hoping to find a nice NewRelic integration that would let me trigger an alert when our queue gets too big or our queue latency is too long. Unfortunately, it seems all the sidekiq and redis plugins for NewRelic don't work well.

So I looked over the options on the sidekiq wiki (https://github.com/mperham/sidekiq/wiki/Monitoring) and settled on this approach:

- Add two new routes which we'll monitor with Pingdom, which will post alerts to Slack. Based off instructions here: https://github.com/mperham/sidekiq/wiki/Monitoring#monitoring-queue-backlog
  - `/queue-status` will return `OK` if the queue size is less than 100, or `UHOH` if it's above 100
  - `/queue-latency` will return `OK` if the queue latency is less then 30 seconds, or `UHOH` if it's above 30 seconds
- Wire up the sidekiq web UI with basic authentication: https://github.com/mperham/sidekiq/wiki/Monitoring#standalone-with-basic-auth
  - The dashboard is accessible at the `/sidekiq` URL
  - Basic authentication to keep things simple. The username is `sidekiq` and the password is set by an environment variable, `SIDEKIQ_DASHBOARD_PASSWORD`

This approach should alert us in Slack when there's a problem through the Pingdom monitoring, and then we can go into the dashboard to see more information about the problem.

I'm submitting this in PR because I had to add some Ruby code to make it all work, and I definitely don't know what I'm doing on that front.

If I made a big goof, you can tell me how to fix it and I'll update the request. My feelings won't be hurt, though, if it's easier for you to checkout my branch and fix it yourself.