### PR TITLE
add is_volunteer and uuid

### DIFF
--- a/db/migrate/20150416002805_add_uuid_and_is_volunteer_to_people.rb
+++ b/db/migrate/20150416002805_add_uuid_and_is_volunteer_to_people.rb
@@ -3,10 +3,13 @@ class AddUuidAndIsVolunteerToPeople < ActiveRecord::Migration
     add_column :people, :uuid, :string
     add_column :people, :is_volunteer, :boolean
     add_index :people, :uuid, unique: true
-  end
-  def up
-    Person.unscoped.each do |person|
-      person.update(uuid: Person.new_uuid)
+
+    reversible do |change|
+      change.up do
+        Person.unscoped.each do |person|
+          person.update(uuid: Person.new_uuid)
+        end
+      end
     end
   end
 end

--- a/db/migrate/20150416002805_add_uuid_and_is_volunteer_to_people.rb
+++ b/db/migrate/20150416002805_add_uuid_and_is_volunteer_to_people.rb
@@ -1,0 +1,12 @@
+class AddUuidAndIsVolunteerToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :uuid, :string
+    add_column :people, :is_volunteer, :boolean
+    add_index :people, :uuid, unique: true
+  end
+  def up
+    Person.unscoped.each do |person|
+      person.update(uuid: Person.new_uuid)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150415195410) do
+ActiveRecord::Schema.define(version: 20150416002805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,13 +150,16 @@ ActiveRecord::Schema.define(version: 20150415195410) do
   create_table "people", force: :cascade do |t|
     t.string   "email"
     t.string   "phone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
     t.string   "first_name"
     t.string   "last_name"
+    t.string   "uuid"
+    t.boolean  "is_volunteer"
   end
 
   add_index "people", ["email"], name: "index_people_on_email", unique: true, using: :btree
+  add_index "people", ["uuid"], name: "index_people_on_uuid", unique: true, using: :btree
 
   create_table "states", force: :cascade do |t|
     t.string   "name"

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -16,12 +16,10 @@ describe Person do
   describe "validations" do
     it "validates with an email and no phone" do
       person = Person.new(email: 'user@example.com')
-      person.valid?
       expect(person.valid?).to be true
     end
     it "validates with a phone and no email" do
       person = Person.new(phone: '555-555-5555')
-      person.save!
       expect(person.valid?).to be true
     end
     it "is invalid with no email or phone" do
@@ -29,6 +27,15 @@ describe Person do
       expect(person.valid?).to be false
     end
   end
+
+  describe "create" do
+    it "generates uuid" do
+      person = Person.create(email: 'user@example.com')
+      expect(person.uuid).to_not be_nil
+      expect(person.uuid.length).to eq 36
+    end
+  end
+
   describe "#called_legislators" do
     it "returns those legislators who are called" do
       connection = FactoryGirl.create(:connection, :completed)


### PR DESCRIPTION
Running migration will create `uuid` for all existing users.

I actually toyed with the idea for having the migration also run code to fetch `is_volunteer` from NB for all users, but figure that might take a few minutes to run and I'm not sure if it's good practice to have a migration take so long. Also considered writing an ActiveJob to sync existing users to NB on specific fields, which might come in handy later if we end up adding more fields to the person model. Should be pretty quick to implement, if desired.