### PR TITLE
update person model and various controllers to make use of uuid and is_v...

### DIFF
--- a/app/controllers/v1/actions_controller.rb
+++ b/app/controllers/v1/actions_controller.rb
@@ -1,19 +1,25 @@
 class V1::ActionsController < V1::BaseController
-
   def create
     activity = Activity.find_by(template_id: params[:template_id])
+
     action = Action.create(person: person_from_params, activity: activity)
     if action.valid?
       output = { success: true }
     else
-      output = { error: 'could not create action' }
+      output = { error: action.errors.full_messages.first }
     end
     render json: output
   end
 
   private
 
-  def person_from_params
-    Person.find_by(email: params[:email]) || Person.find_by(phone: params[:phone])
+  def person_params
+    params.require(:person).permit(:uuid, :email, :phone)
   end
+
+  def person_from_params
+    person = Person.create_or_update(person_params)
+    person if person.valid?
+  end
+
 end

--- a/app/controllers/v1/base_controller.rb
+++ b/app/controllers/v1/base_controller.rb
@@ -11,4 +11,8 @@ class V1::BaseController < ApplicationController
     end
   end
 
+  rescue_from ActionController::ParameterMissing do |exception|
+    render json: { error: "#{exception.param} is required" }, status: 422
+  end
+
 end

--- a/app/controllers/v1/nominations_controller.rb
+++ b/app/controllers/v1/nominations_controller.rb
@@ -29,8 +29,8 @@ class V1::NominationsController < V1::BaseController
   private
 
   def person_params
-    params.permit(:email, :phone, :first_name, :last_name, :zip,
-                  remote_fields: [:event_id, :is_volunteer, tags: []])
+    params.permit(:email, :phone, :first_name, :last_name, :zip, :is_volunteer,
+                  remote_fields: [:event_id, tags: []])
   end
 
   def nomination_params

--- a/app/controllers/v1/people_controller.rb
+++ b/app/controllers/v1/people_controller.rb
@@ -1,13 +1,13 @@
 class V1::PeopleController < V1::BaseController
 
   def create
-    person = Person.create_with(person_params).find_or_create_by(email: person_params[:email])
+    person = Person.create_or_update(person_params)
     if person.valid?
       output = { id: person.id }
     else
       output = { error: person.error_message_output }
     end
-    render json: output , status: 200
+    render json: output
   end
 
   def targets
@@ -25,8 +25,8 @@ class V1::PeopleController < V1::BaseController
   private
 
   def person_params
-    params.fetch(:person, {}).permit(:email, :phone, :first_name, :last_name,
-      :address, :zip, remote_fields: [:event_id, :is_volunteer, tags: []])
+    params.require(:person).permit(:email, :phone, :first_name, :last_name,
+      :address, :zip, :is_volunteer, remote_fields: [:event_id, tags: []])
   end
 
   def location_params

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -41,16 +41,22 @@ class Person < ActiveRecord::Base
   FIELDS_ALSO_ON_NB = %w[email first_name is_volunteer last_name phone]
 
   def self.create_or_update(person_params)
-    if email = person_params.delete(:email)
-      find_or_initialize_by(email: email).tap{ |p| p.update(person_params) }
+    key = nil
+    [:uuid, :email, :phone].each do |field|
+      if value = person_params.delete(field).presence
+        key = { field => value }
+        break
+      end
+    end
+    if key
+      find_or_initialize_by(key).tap{ |p| p.update(person_params) }
+    else
+      Person.create(person_params)
     end
   end
 
   def self.new_uuid
-    loop do
-      token = SecureRandom.uuid
-      break token unless Person.where(uuid: token).any?
-    end
+    SecureRandom.uuid
   end
 
   def location

--- a/spec/controllers/v1/actions_controller_spec.rb
+++ b/spec/controllers/v1/actions_controller_spec.rb
@@ -3,22 +3,19 @@ require 'rails_helper'
 RSpec.describe V1::ActionsController, type: :controller do
   describe "#create" do
     before do
-      FactoryGirl.create(:activity, template_id: 'foo')
+      FactoryGirl.create(:activity, template_id: 'real_id')
       FactoryGirl.create(:person, phone: '510-555-4444', email: 'joe@example.com')
     end
-    let (:person) {  }
-    it "creates action based on phone" do
-      post :create, phone: '510-555-4444', template_id: 'foo'
-      expect(JSON.parse(response.body)['success']).to be true
-    end
-    it "creates action based on email" do
-      post :create, email: 'joe@example.com', template_id: 'foo'
+    it "creates action with good parameters" do
+      expect(Person).to receive(:create_or_update).with(uuid: 'the_uuid', phone: '510-555-4444')
+        .and_call_original
+      post :create, person: { uuid: 'the_uuid', phone: '510-555-4444' }, template_id: 'real_id'
       expect(JSON.parse(response.body)['success']).to be true
     end
     it "doesn't create action if missing parameters" do
-      post :create, template_id: 'foo'
+      post :create, template_id: 'real_id'
       expect(JSON.parse(response.body)['success']).to be_nil
-      expect(JSON.parse(response.body)['error']).to_not be_nil
+      expect(JSON.parse(response.body)['error']).to eq 'person is required'
     end
   end
 end

--- a/spec/controllers/v1/people_controller_spec.rb
+++ b/spec/controllers/v1/people_controller_spec.rb
@@ -4,12 +4,12 @@ describe V1::PeopleController,  type: :controller do
   describe "POST create" do
     it "returns success" do
       user = instance_double("Person", id: 3, valid?: true)
-      allow(Person).to receive_message_chain(:create_with, :find_or_create_by).and_return(user)
+      allow(Person).to receive(:create_or_update).and_return(user)
 
       post :create, person: { email: 'user@example.com', remote_fields: { tags: ['test'] } }
       json_response = JSON.parse(response.body)
 
-      expect(Person).to have_received(:create_with)
+      expect(Person).to have_received(:create_or_update)
         .with(email: 'user@example.com', remote_fields: { tags: ['test'] })
       expect(response).to be_success
       expect(json_response).to have_key('id')
@@ -21,7 +21,7 @@ describe V1::PeopleController,  type: :controller do
       json_response = JSON.parse(response.body)
 
       expect(json_response).to have_key('error')
-      expect(json_response['error']).to eq("Email can't be blank. Phone can't be blank.")
+      expect(json_response['error']).to eq("person is required")
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -58,11 +58,18 @@ describe Person do
     end
     context "existing record" do
       it "updates record with appropriate values" do
-        FactoryGirl.create(:person, email: 'user@example.com')
+        person = FactoryGirl.create(:person, email: 'user@example.com')
         hash = { email: 'user@example.com',
                  phone: '555-555-1111' }
-        person = Person.create_or_update(hash)
-        expect(person.slice(*hash.keys).values).to eq hash.values
+        Person.create_or_update(hash)
+        expect(person.reload.slice(*hash.keys).values).to eq hash.values
+      end
+      it "finds user based on uuid, if present" do
+        person = FactoryGirl.create(:person, uuid: 'good-uuid', email: 'user@example.com',)
+        hash = { email: 'new_email_address@example.com',
+                 uuid:  'good-uuid' }
+        Person.create_or_update(hash)
+        expect(person.reload.slice(*hash.keys).values).to eq hash.values
       end
     end
   end


### PR DESCRIPTION
updated `person_params` in relevant controllers, moving `is_volunteer` out of `remote_fields`. 
**NOTE: this will require a change on the frontend as well**

changed `Person.create_or_update` to work with `uuid` and `phone`, in addition to `email`. 
**NOTE: there's no unique constraint on phone, so this may be dangerous.**
Presumably we should add that constraint, but I suppose it's possible that people could share a phone (e.g., if multiple people in same house want to use a landline to make calls)

added error handling for missing params in API