### PR TITLE
Person: skip_nb_update doesn't also skip save_location

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,7 +40,8 @@ class Person < ActiveRecord::Base
 
   before_create :generate_uuid, unless: :uuid?
   before_save :downcase_email
-  after_save :update_nation_builder, :save_location, unless: :skip_nb_update
+  after_save :update_nation_builder, unless: :skip_nb_update
+  after_save :save_location
 
   scope :identify, -> identifier {
     includes(:actions)


### PR DESCRIPTION
I didn't notice that I was skipping two callbacks when I created the `skip_nb_update` flag. This fixes the problem.