### PR TITLE
extract LocationUpdater and LocationComparer classes

### DIFF
--- a/app/services/location_comparer.rb
+++ b/app/services/location_comparer.rb
@@ -1,0 +1,31 @@
+class LocationComparer
+  def initialize(old_city: nil, old_state: nil, old_zip: nil,
+                 new_city: nil, new_state: nil, new_zip: nil)
+    @old_city = old_city
+    @old_state = old_state
+    @old_zip = old_zip
+    @new_city = new_city
+    @new_state = new_state
+    @new_zip = new_zip
+  end
+
+  def different?
+    different_zip? || different_state? || different_city?
+  end
+
+  private
+
+  attr_reader :old_city, :old_state, :old_zip, :new_city, :new_state, :new_zip
+
+  def different_zip?
+    new_zip && new_zip != old_zip
+  end
+
+  def different_city?
+    new_city && old_city && new_city != old_city
+  end
+
+  def different_state?
+    new_state && new_state != old_state
+  end
+end

--- a/app/services/location_updater.rb
+++ b/app/services/location_updater.rb
@@ -1,0 +1,106 @@
+class LocationUpdater
+  def initialize(location, address_params)
+    @location = location
+    @address_params = address_params
+  end
+
+  def update
+    if sufficient_address?
+      location.update_attributes(relevant_attributes)
+    end
+  end
+
+  private
+
+  attr_reader :location, :address_params
+
+  def sufficient_address?
+    find_zip_code || new_state
+  end
+
+  def relevant_attributes
+    if discard_old_values?
+      new_attributes
+    else
+      new_attributes.compact
+    end
+  end
+
+  def new_attributes
+    {
+      address_1: new_address,
+      city:      new_city,
+      zip_code:  new_zip,
+      district:  find_district,
+      state:     find_state,
+    }
+  end
+
+  def discard_old_values?
+    existing_location? && different_address?
+  end
+
+  def existing_location?
+    [
+      location.address_1,
+      location.city,
+      location.state,
+      location.zip_code,
+    ].any?
+  end
+
+  def different_address?
+    LocationComparer.new(
+      new_city: new_city,
+      new_state: new_state,
+      new_zip: new_zip,
+      old_city: location.city,
+      old_state: location.state,
+      old_zip: location.zip_code,
+    ).different?
+  end
+
+  def find_district
+    @_find_district ||= find_district_by_zip || find_district_by_address
+  end
+
+  def find_district_by_zip
+    find_zip_code.try(:single_district)
+  end
+
+  def find_district_by_address
+    if new_address && new_zip
+      search_params = address_params.clone
+      search_params[:state] = search_params.delete(:state_abbrev)
+      District.find_by_address(search_params)
+    end
+  end
+
+  def find_state
+    new_state || find_zip_code.try(:state)
+  end
+
+  def find_zip_code
+    @_find_zip_code ||= ZipCode.find_by(zip_code: new_zip)
+  end
+
+  def new_zip
+    if ZipCode.valid_zip?(address_params[:zip])
+      address_params[:zip]
+    end
+  end
+
+  def new_state
+    @_new_state ||= if address_params[:state_abbrev]
+                      State.find_by(abbrev: address_params[:state_abbrev])
+                    end
+  end
+
+  def new_city
+    address_params[:city]
+  end
+
+  def new_address
+    address_params[:address]
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -32,9 +32,11 @@ FactoryGirl.define do
 
   factory :location do
     person
-    district
-    state { district.state }
-    sequence(:zip_code) { |n| "2#{n.to_s.rjust(4,'0')}" }
+
+    trait :with_district_and_state do
+      district
+      state { district.state }
+    end
   end
 
   factory :event do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -26,125 +26,21 @@ describe Location do
   end
 
   describe "#update_location" do
-    let(:location) { FactoryGirl.create(:location, zip_code: '03431') }
-    context "with a bad address" do
-      it "doesn't change location" do
-        expect{
-          location.update_location(address: '2020 Oregon St', zip: 'bad')
-          }.not_to change{location.attributes}
-      end
-    end
+    it "updates via LocationUpdater" do
+      updater = spy(:location_updater)
+      allow(LocationUpdater).to receive(:new).and_return(updater)
+      location = Location.new
 
-    context "with a good address" do
-      let (:state)    { FactoryGirl.create(:state, abbrev: 'CA') }
-      let!(:district) { FactoryGirl.create(:district, state: state, district: '13') }
+      location.update_location(:address_params)
 
-      before do
-        location.update_location(address: '2020 Oregon St', zip: '94703')
-      end
-
-      it "sets address" do
-        expect(location.address_1).to eq '2020 Oregon St'
-      end
-      it "sets district" do
-        expect(location.district).to eq district
-      end
-      it "sets state" do
-        expect(location.state).to eq state
-      end
-      it "sets zip" do
-        expect(location.zip_code).to eq '94703'
-      end
-    end
-
-    context "with zip only" do
-      context "with same zip already stored" do
-        it "doesn't change location" do
-          original_attributes = location.attributes
-          location.update_location(zip: '03431')
-          expect(location.attributes).to eq original_attributes
-        end
-      end
-
-      context "with different zip already stored" do
-        context "for invalid zip" do
-          it "doesn't change location" do
-            original_attributes = location.attributes
-            location.update_location(zip: '999999')
-            expect(location.attributes).to eq original_attributes
-          end
-        end
-        context "for zip found" do
-          let!(:zip) { FactoryGirl.create(:zip_code, zip_code: '94703') }
-          let!(:district) { FactoryGirl.create(:district) }
-
-          context "with multiple districts" do
-            before do
-              zip.districts = [district, FactoryGirl.create(:district)]
-              location.update_location(zip: '94703')
-            end
-
-            it "clears address" do
-              expect(location.address_1).to be_nil
-            end
-            it "clears district" do
-              expect(location.district).to be_nil
-            end
-            it "sets state" do
-              expect(location.state).to eq zip.state
-            end
-            it "sets zip" do
-              expect(location.zip_code).to eq '94703'
-            end
-          end
-          context "with single district" do
-            before do
-              zip.districts = [district]
-              location.update_location(zip: '94703')
-            end
-
-            it "clears address" do
-              expect(location.address_1).to be_nil
-            end
-            it "sets district" do
-              expect(location.district).to eq district
-            end
-            it "sets state" do
-              expect(location.state).to eq zip.state
-            end
-            it "sets zip" do
-              expect(location.zip_code).to eq '94703'
-            end
-          end
-        end
-
-        context "for zip not found" do
-          before do
-            allow(ZipCode).to receive(:find_by).and_return(nil)
-          end
-
-          it "clears district" do
-            expect{
-              location.update_location(zip: '94703')
-            }.not_to change{location.district}
-          end
-          it "clears state" do
-            expect{
-              location.update_location(zip: '94703')
-            }.not_to change{location.state}
-          end
-          it "sets zip" do
-            expect{
-              location.update_location(zip: '94703')
-            }.not_to change{location.zip_code}
-          end
-        end
-      end
+      expect(LocationUpdater).to have_received(:new).
+        with(location, :address_params)
+      expect(updater).to have_received(:update)
     end
   end
 
   describe "#update_nation_builder" do
-    let(:person) { FactoryGirl.create(:person, email: 'user@example.com') }
+    let(:person) { create(:person, email: 'user@example.com') }
     let(:location_attributes) do
       {
         address_1:    nil,

--- a/spec/services/location_comparer_spec.rb
+++ b/spec/services/location_comparer_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe LocationComparer do
+  describe "#different?" do
+    different_addresses = [
+      { old_zip: 'old', new_zip: 'new' },
+      { old_state: 'old', new_state: 'new' },
+      { old_state: 'same', old_city: 'old',
+        new_state: 'same', new_city: 'new' },
+    ]
+
+    different_addresses.each do |different_address|
+      it "returns true for #{different_address}" do
+        comparer = LocationComparer.new(different_address)
+
+        result = comparer.different?
+
+        expect(result).to be true
+      end
+    end
+
+    similar_addresses = [
+      { old_zip: 'same', new_zip: 'same' },
+      { old_state: 'same', new_state: 'same' },
+      { old_state: 'same', old_city: nil,
+        new_state: 'same', new_city: 'new' },
+    ]
+
+    similar_addresses.each do |similar_address|
+      it "returns false for #{similar_address}" do
+        comparer = LocationComparer.new(similar_address)
+
+        result = comparer.different?
+
+        expect(result).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/services/location_updater_spec.rb
+++ b/spec/services/location_updater_spec.rb
@@ -1,0 +1,193 @@
+require 'rails_helper'
+
+describe LocationUpdater do
+  describe "#update" do
+    bad_addresses = [
+      { zip: 'bad' },
+      { state_abbrev: 'bad' },
+      { address: 'address', city: 'city' },
+    ]
+
+    bad_addresses.each do |bad_address|
+      it "doesn't update location for bad address: #{bad_address}" do
+        location = build_stubbed_location
+        updater = LocationUpdater.new(location, bad_address)
+
+        updater.update
+
+        expect(location).not_to have_received(:update_attributes)
+      end
+    end
+
+    it "ignores zip codes with wrong format" do
+      address = { zip: 'wrong format', state_abbrev: 'AA' }
+      state = stub_state_find('AA')
+      location = build_stubbed_location
+      updater = LocationUpdater.new(location, address)
+
+      updater.update
+
+      expect(location).to have_received(:update_attributes).
+        with(state: state)
+    end
+
+    it "finds state based on abbrev" do
+      address = { zip: '12345', state_abbrev: 'AA' }
+      state = stub_state_find('AA')
+      location = build_stubbed_location
+      updater = LocationUpdater.new(location, address)
+
+      updater.update
+
+      expect(location).to have_received(:update_attributes).
+        with(zip_code: '12345', state: state)
+    end
+
+    it "finds state based on zip if no state provided" do
+      address = { zip: '12345' }
+      zip_code = stub_zip_code_find('12345')
+      location = build_stubbed_location
+      updater = LocationUpdater.new(location, address)
+
+      updater.update
+
+      expect(location).to have_received(:update_attributes).
+        with(zip_code: '12345', state: zip_code.state)
+    end
+
+    it "finds district based on zip if zip has only one district" do
+      address = { address: 'address', zip: '12345' }
+      zip_code = stub_zip_code_find('12345', district: 'district')
+      location = build_stubbed_location
+      updater = LocationUpdater.new(location, address)
+      stub_district_find_by_address
+
+      updater.update
+
+      expect(location).to have_received(:update_attributes).
+        with(hash_including(district: 'district'))
+      expect(District).not_to have_received(:find_by_address)
+    end
+
+    it "finds district based on address if address and zip present" do
+      address = { address: 'address', zip: '12345' }
+      zip_code = stub_zip_code_find('12345')
+      location = build_stubbed_location
+      updater = LocationUpdater.new(location, address)
+      stub_district_find_by_address('district')
+
+      updater.update
+
+      expect(District).to have_received(:find_by_address).
+        with(hash_including(address: 'address', zip: '12345'))
+      expect(location).to have_received(:update_attributes).
+        with(hash_including(district: 'district'))
+    end
+
+    context "with no existing location data" do
+      it "ignores nils when updating" do
+        address = { state_abbrev: 'AL' }
+        state = stub_state_find('AL')
+        location = build_stubbed_location
+        updater = LocationUpdater.new(location, address)
+
+        updater.update
+
+        expect(location).to have_received(:update_attributes).
+          with(state: state)
+      end
+
+      it "doesn't compare locations" do
+        address = { state_abbrev: 'AL' }
+        state = stub_state_find('AL')
+        location = build_stubbed_location
+        stub_location_comparer
+        updater = LocationUpdater.new(location, address)
+
+        updater.update
+
+        expect(LocationComparer).not_to have_received(:new)
+      end
+    end
+
+    context "with existing location data" do
+      it "compares locations" do
+        address = { city: 'city', state_abbrev: 'AA', zip: '12345' }
+        state = stub_state_find('AA')
+        stub_zip_code_find('12345')
+        location = build_stubbed_location(
+          city: 'city', state: state, zip_code: '12345'
+        )
+        stub_location_comparer
+        updater = LocationUpdater.new(location, address)
+
+        updater.update
+
+        expect(LocationComparer).to have_received(:new).
+          with(new_city: 'city', new_state: state, new_zip: '12345',
+               old_city: 'city', old_state: state, old_zip: '12345')
+      end
+
+      it "preserves old data if locations are similar" do
+        address = { zip: '12345' }
+        stub_zip_code_find('12345')
+        location = build_stubbed_location(city: 'city', zip_code: '12345')
+        stub_location_comparer(different: false)
+        updater = LocationUpdater.new(location, address)
+
+        updater.update
+
+        expect(location).to have_received(:update_attributes).
+          with(hash_excluding(:city))
+      end
+
+      it "overwrites old data if locations are different" do
+        address = { zip: '12345' }
+        stub_zip_code_find('12345')
+        location = build_stubbed_location(zip_code: '11111')
+        stub_location_comparer(different: true)
+        updater = LocationUpdater.new(location, address)
+
+        updater.update
+
+        expect(location).to have_received(:update_attributes).
+          with(hash_including(*all_location_fields))
+      end
+    end
+  end
+
+  def all_location_fields
+    [ :address_1, :city, :state, :zip_code ]
+  end
+
+  def stub_district_find_by_address(district = nil)
+    allow(District).to receive(:find_by_address).and_return(district)
+  end
+
+  def stub_location_comparer(different: false)
+    location_comparer = double(:location_comparer)
+    allow(location_comparer).to receive(:different?).and_return(different)
+    allow(LocationComparer).to receive(:new).and_return(location_comparer)
+    location_comparer
+  end
+
+  def build_stubbed_location(params = nil)
+    location = build_stubbed(:location, params)
+    allow(location).to receive(:update_attributes)
+    location
+  end
+
+  def stub_state_find(abbrev)
+    state = State.new(abbrev: abbrev)
+    allow(State).to receive(:find_by).with(abbrev: abbrev).and_return(state)
+    state
+  end
+
+  def stub_zip_code_find(zip, district: nil)
+    zip_code = build_stubbed(:zip_code)
+    allow(zip_code).to receive(:single_district).and_return(district)
+    allow(ZipCode).to receive(:valid_zip?).with(zip).and_return(true)
+    allow(ZipCode).to receive(:find_by).with(zip_code: zip).and_return(zip_code)
+    zip_code
+  end
+end


### PR DESCRIPTION
this ended up being a lot bigger than I expected.

Next step is to remove `update_location` from `Location` and just call `LocationUpdater` directly from `Person`. Then remove it from `Person` by creating `PersonWithLocation` service object, or adding `LocationUpdater` to `PersonWithRemoteFields` and/or `PersonConstructor`?