### PR TITLE
Donations: Accept person and person params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,3 @@
 class ApplicationController < ActionController::API
   # protect_from_forgery with: :null_session
-  rescue_from ActiveRecord::RecordNotFound, :with => :record_not_found
-
-  private
-    def record_not_found(error)
-      render :json => {:error => error.message}, :status => :not_found
-    end
 end

--- a/app/controllers/v1/actions_controller.rb
+++ b/app/controllers/v1/actions_controller.rb
@@ -1,5 +1,4 @@
 class V1::ActionsController < V1::BaseController
-  before_action :set_person, only: :create
 
   def index
     @activity = Activity.find_by(template_id: params[:activity_template_id])
@@ -18,6 +17,7 @@ class V1::ActionsController < V1::BaseController
 
   def create
     activity = Activity.find_or_create_by(template_id: activity_param)
+    @person = person_from_params
 
     action_attributes = {person: @person, activity: activity}.merge(action_params)
     action = Action.create(action_attributes)
@@ -50,15 +50,6 @@ class V1::ActionsController < V1::BaseController
     params.permit(:utm_source, :utm_medium, :utm_campaign, :source_url,
                   :donation_amount_in_cents, :strike_amount_in_cents,
                   :privacy_status)
-  end
-
-  def person_params
-    params.require(:person).permit(Person::PERMITTED_PUBLIC_FIELDS)
-  end
-
-  def set_person
-    person_params.map{|k,v| person_params[k] = v.try(:strip) || v }
-    @person = Person.create_or_update(person_params) if person_params.present?
   end
 
 end

--- a/app/controllers/v1/base_controller.rb
+++ b/app/controllers/v1/base_controller.rb
@@ -1,5 +1,8 @@
 class V1::BaseController < ApplicationController
 
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ActionController::ParameterMissing, with: :missing_parameter
+
   protected
 
   def rescue_error_messages
@@ -11,17 +14,30 @@ class V1::BaseController < ApplicationController
     end
   end
 
-  rescue_from ActionController::ParameterMissing do |exception|
-    render json: { error: "#{exception.param} is required" }, status: 422
+  def missing_parameter(error)
+    render json: { error: "#{error.param} is required" }, status: 422
+  end
+
+  def record_not_found(error)
+    render json: {error: error.message}, status: :not_found
+  end
+
+  def default_person_params
+    params.require(:person).permit(Person::ALL_AVAILABLE_ATTRIBUTES)
+  end
+
+  def person_from_params
+    default_person_params.map{|k,v| default_person_params[k] = v.try(:strip) || v }
+    Person.create_or_update(default_person_params) if default_person_params.present?
   end
 
   def create_person_and_action(default_template_id: nil)
-    person_params = params.require(:person).permit(Person::PERMITTED_PUBLIC_FIELDS)
-    person_params.merge! params[:person].slice(*Person::SUPPLEMENTARY_ATTRIBUTES)
+    person_params = default_person_params
+    person = Person.create_or_update(person_params)
+
     action_params = params.permit(:template_id, :utm_source, :utm_medium, :utm_campaign, :source_url)
     action_params[:template_id] ||= default_template_id
 
-    person = Person.create_or_update(person_params)
     person.create_action(action_params.symbolize_keys)
 
     person

--- a/app/controllers/v1/donation_pages_controller.rb
+++ b/app/controllers/v1/donation_pages_controller.rb
@@ -19,7 +19,7 @@ class V1::DonationPagesController < ApplicationController
       donation_page.reload
       render json: { uuid: donation_page.uuid }, status: :created
     else
-      render json: { errors: merge_errors(person, donation_page) },
+      render json: { error: merge_errors(person, donation_page) },
         status: :unprocessable_entity
     end
   end

--- a/app/controllers/v1/donations_controller.rb
+++ b/app/controllers/v1/donations_controller.rb
@@ -1,9 +1,10 @@
 class V1::DonationsController < V1::BaseController
+  before_action :set_person
 
   # Receives person, payment and action attributes. Creates/updates a person
   # creates an action, and creates a stripe single or recurring payment
   # Params:
-  #  * email - string - person email
+  #  * person - hash - person hash
   #  * employer - string - person employer
   #  * occupation - string - person occupation
   #  * amount_in_cents - int - donation amount in cents
@@ -15,19 +16,28 @@ class V1::DonationsController < V1::BaseController
   #  * utm_campaign - action utm_campaign
   #  * source_url - action source_url
   def create
-    donation = Donation.new(donation_params)
+    donation = Donation.new(donation_params.merge(person: @person))
     if donation.process
       render json: { status: 'success' }
     else
-      render json: { errors: donation.errors }
+      render json: { error: donation.errors }
     end
   end
 
   private
 
   def donation_params
-    params.permit(:email, :employer, :occupation, :stripe_token, :recurring,
+    params.permit(:employer, :occupation, :stripe_token, :recurring,
                   :amount_in_cents, :utm_source, :utm_medium, :utm_campaign,
                   :source_url, :template_id)
+  end
+
+  def person_params
+    params.require(:person).permit(Person::PERMITTED_PUBLIC_FIELDS)
+  end
+
+  def set_person
+    person_params.map{|k,v| person_params[k] = v.try(:strip) || v }
+    @person = Person.create_or_update(person_params) if person_params.present?
   end
 end

--- a/app/controllers/v1/donations_controller.rb
+++ b/app/controllers/v1/donations_controller.rb
@@ -1,5 +1,4 @@
 class V1::DonationsController < V1::BaseController
-  before_action :set_person
 
   # Receives person, payment and action attributes. Creates/updates a person
   # creates an action, and creates a stripe single or recurring payment
@@ -16,7 +15,8 @@ class V1::DonationsController < V1::BaseController
   #  * utm_campaign - action utm_campaign
   #  * source_url - action source_url
   def create
-    donation = Donation.new(donation_params.merge(person: @person))
+    person = person_from_params
+    donation = Donation.new(donation_params.merge(person: person))
     if donation.process
       render json: { status: 'success' }
     else
@@ -32,12 +32,4 @@ class V1::DonationsController < V1::BaseController
                   :source_url, :template_id)
   end
 
-  def person_params
-    params.require(:person).permit(Person::PERMITTED_PUBLIC_FIELDS)
-  end
-
-  def set_person
-    person_params.map{|k,v| person_params[k] = v.try(:strip) || v }
-    @person = Person.create_or_update(person_params) if person_params.present?
-  end
 end

--- a/app/controllers/v1/people_controller.rb
+++ b/app/controllers/v1/people_controller.rb
@@ -23,7 +23,7 @@ class V1::PeopleController < V1::BaseController
     if @person.valid?
       render
     else
-      render json: {errors: @person.error_message_output}, status: :unprocessable_entity
+      render json: {error: @person.error_message_output}, status: :unprocessable_entity
     end
   end
 

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -25,10 +25,10 @@ class District < ActiveRecord::Base
     joins(:state).where(states: { abbrev: state }).find_by(district: district)
   end
 
-  def self.find_by_address(address:, zip:, city: nil, state: nil, includes: nil)
+  def self.find_by_address(address:, zip:, city: nil, state_abbrev: nil, includes: nil)
     results = Integration::Here.geocode_address( address: address,
                                                  city:    city,
-                                                 state:   state,
+                                                 state:   state_abbrev,
                                                  zip:     zip )
     if coords = results[:coordinates]
       if district_hash = Integration::MobileCommons.district_from_coords(coords)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -30,7 +30,7 @@ class Donation
   private
 
   def process_payment
-    if recurring
+    if ActiveRecord::Type::Boolean.new.type_cast_from_user(recurring)
       stripe_customer = StripeCustomer.new(create_stripe_customer)
       person.update(stripe_id: stripe_customer.id)
       person.create_subscription(remote_id: stripe_customer.subscription_id)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -22,7 +22,7 @@ class Donation
       false
     end
 
-  rescue Stripe::CardError => e
+  rescue Stripe::CardError, Stripe::InvalidRequestError => e
     errors.add(:stripe_token, e.json_body[:error][:message])
     false
   end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,12 +1,12 @@
 class Donation
   include ActiveModel::Model
 
-  attr_accessor :email, :employer, :occupation, :stripe_token, :recurring,
+  attr_accessor :person, :employer, :occupation, :stripe_token, :recurring,
     :utm_source, :utm_medium, :utm_campaign, :source_url, :amount_in_cents
 
   attr_writer :template_id
 
-  validates :email, presence: true, email_format: true
+  validates :person, presence: true
   validates :employer, presence: true
   validates :occupation, presence: true
   validates :stripe_token, presence: true
@@ -15,7 +15,6 @@ class Donation
 
   def process
     if valid?
-      find_or_create_person
       process_payment
       record_donation
       create_donate_action
@@ -30,8 +29,6 @@ class Donation
 
   private
 
-  attr_reader :person
-
   def process_payment
     if recurring
       stripe_customer = StripeCustomer.new(create_stripe_customer)
@@ -43,7 +40,7 @@ class Donation
   end
 
   def record_donation
-    person = { email: email, employer: employer, occupation: occupation }
+    person = { email: self.person.email, employer: employer, occupation: occupation }
     NbDonationCreateJob.perform_later(amount_as_integer, person)
   end
 
@@ -60,15 +57,11 @@ class Donation
     @template_id ||= Activity::DEFAULT_TEMPLATE_IDS[:donate]
   end
 
-  def find_or_create_person
-    @person = Person.find_or_initialize_by(email: email)
-    @person.update(skip_nb_update: true)
-  end
 
   def create_stripe_customer
     Stripe::Customer.create(source: stripe_token,
                             plan: 'one_dollar_monthly',
-                            email: email,
+                            email: person.email,
                             quantity: amount_as_integer/100)
   end
 
@@ -76,7 +69,7 @@ class Donation
     Stripe::Charge.create(amount: amount_as_integer,
                           source: stripe_token,
                           currency: 'usd',
-                          description: "donation from #{email}")
+                          description: "donation from #{self.person.email}")
   end
 
   def amount_as_integer

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -56,7 +56,7 @@ class Person < ActiveRecord::Base
   LOCATION_ATTRIBUTES = [:address, :zip, :city, :state_abbrev]
   DEFAULT_TARGET_COUNT = 100
 
-  SUPPLEMENTARY_ATTRIBUTES = [:remote_fields] + LOCATION_ATTRIBUTES
+  SUPPLEMENTARY_ATTRIBUTES = [:remote_fields, :full_name] + LOCATION_ATTRIBUTES
   ALL_AVAILABLE_ATTRIBUTES = PERMITTED_PUBLIC_FIELDS + LOCATION_ATTRIBUTES
   attr_accessor *SUPPLEMENTARY_ATTRIBUTES, :skip_nb_update
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -52,11 +52,12 @@ class Person < ActiveRecord::Base
   delegate :update_location, :district, :state, to: :location
 
   FIELDS_ALSO_ON_NB = %w[email first_name last_name is_volunteer phone]
-  PERMITTED_PUBLIC_FIELDS = [:email, :phone, :first_name, :last_name, :address, :city, :state_abbrev, :zip, :is_volunteer, remote_fields: [:event_id, :employer, :occupation, :skills, tags: []]]
+  PERMITTED_PUBLIC_FIELDS = [:email, :phone, :first_name, :last_name, :full_name, :address, :city, :state_abbrev, :zip, :is_volunteer, remote_fields: [:event_id, :employer, :occupation, :skills, tags: []]]
   LOCATION_ATTRIBUTES = [:address, :zip, :city, :state_abbrev]
   DEFAULT_TARGET_COUNT = 100
 
   SUPPLEMENTARY_ATTRIBUTES = [:remote_fields] + LOCATION_ATTRIBUTES
+  ALL_AVAILABLE_ATTRIBUTES = PERMITTED_PUBLIC_FIELDS + LOCATION_ATTRIBUTES
   attr_accessor *SUPPLEMENTARY_ATTRIBUTES, :skip_nb_update
 
   def self.create_or_update(person_params)

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,6 +1,7 @@
 Rails.configuration.stripe = {
-  :publishable_key => ENV['STRIPE_PUBLISHABLE_KEY'],
-  :secret_key      => ENV['STRIPE_SECRET_KEY']
+  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
+  secret_key:      ENV['STRIPE_SECRET_KEY'],
+  api_version:     "2016-02-19"
 }
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/spec/controllers/v1/donations_controller_spec.rb
+++ b/spec/controllers/v1/donations_controller_spec.rb
@@ -7,9 +7,9 @@ describe V1::DonationsController, type: :controller do
       donation = double('donation', process: false, errors: { foo: ['bad'] })
       allow(Donation).to receive(:new).and_return(donation)
 
-      post :create, bad_param: 'nonsense'
+      post :create, bad_param: 'nonsense', person: {email: 'some@email.com'}
 
-      expect(json(response)).to eq({ "errors" => {"foo"=>["bad"]} })
+      expect(json(response)).to eq({ "error"=> {"foo"=>["bad"]} })
     end
   end
 

--- a/spec/controllers/v1/people_controller_spec.rb
+++ b/spec/controllers/v1/people_controller_spec.rb
@@ -41,8 +41,8 @@ describe V1::PeopleController,  type: :controller do
       it "returns error" do
         get :targets, person: { email: 'bad' }
         json_response = JSON.parse(response.body)
-        expect(json_response).to have_key('errors')
-        expect(json_response['errors']).to eq("Email is invalid.")
+        expect(json_response).to have_key('error')
+        expect(json_response['error']).to eq("Email is invalid.")
       end
     end
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -34,11 +34,23 @@ describe Donation do
         with(remote_id: 'subscription id')
     end
 
-    it "charges stripe once if recurring is falsy" do
+    it "charges stripe once if recurring not provideded" do
       allow(Stripe::Charge).to receive(:create)
       person = stub_person
       donation = Donation.new(amount_in_cents: 400, stripe_token: 'test token',
         person: person, occupation: 'job', employer: 'work place')
+
+      donation.process
+
+      expect(Stripe::Charge).to have_received(:create).
+        with(hash_including(amount: 400, source: 'test token', currency: 'usd'))
+    end
+
+    it "charges stripe once if recurring is falsy" do
+      allow(Stripe::Charge).to receive(:create)
+      person = stub_person
+      donation = Donation.new(amount_in_cents: 400, stripe_token: 'test token',
+        person: person, occupation: 'job', employer: 'work place', recurring: 'false')
 
       donation.process
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -3,8 +3,7 @@ require 'validates_email_format_of/rspec_matcher'
 
 describe Donation do
 
-  it { should validate_presence_of(:email) }
-  it { should validate_email_format_of(:email) }
+  it { should validate_presence_of(:person) }
   it { should validate_presence_of(:stripe_token) }
   it { should validate_presence_of(:employer) }
   it { should validate_presence_of(:occupation) }
@@ -13,18 +12,18 @@ describe Donation do
 
   describe "process" do
     it "creates subscription if recurring is true" do
-      person = stub_person_find_or_initialize_by
+      person = stub_person
       stub_stripe_customer_create(id: 'customer id',
                                   subscription_id: 'subscription id')
       donation = Donation.new(amount_in_cents: 400, stripe_token: 'test token',
-        recurring: true, email: 'user@example.com', occupation: 'job',
+        recurring: true, person: person, occupation: 'job',
         employer: 'work place')
 
       donation.process
 
       expect(Stripe::Customer).to have_received(:create).
         with(plan: 'one_dollar_monthly',
-         email: 'user@example.com',
+         email: person.email,
          quantity: 4,
          source: 'test token')
       expect(person).to have_received(:update).with(stripe_id: 'customer id')
@@ -34,9 +33,9 @@ describe Donation do
 
     it "charges stripe once if recurring is falsy" do
       allow(Stripe::Charge).to receive(:create)
-      stub_person_find_or_initialize_by
+      person = stub_person
       donation = Donation.new(amount_in_cents: 400, stripe_token: 'test token',
-        email: 'user@example.com', occupation: 'job', employer: 'work place')
+        person: person, occupation: 'job', employer: 'work place')
 
       donation.process
 
@@ -46,22 +45,22 @@ describe Donation do
 
     it "updates CRM with donation info" do
       allow(Stripe::Charge).to receive(:create)
-      stub_person_find_or_initialize_by
+      person = stub_person
       allow(NbDonationCreateJob).to receive(:perform_later)
       donation = Donation.new(amount_in_cents: 400, stripe_token: 'test token',
-        email: 'user@example.com', occupation: 'job', employer: 'work place')
+        person: person, occupation: 'job', employer: 'work place')
 
       donation.process
 
       expect(NbDonationCreateJob).to have_received(:perform_later).
-        with(400, { email: 'user@example.com', occupation: 'job', employer: 'work place' })
+        with(400, { email: person.email, occupation: 'job', employer: 'work place' })
     end
 
     it "creates donate action on person" do
       allow(Stripe::Charge).to receive(:create)
-      person = stub_person_find_or_initialize_by
+      person = stub_person
       donation = Donation.new(amount_in_cents: 400, stripe_token: 'test token',
-        email: 'user@example.com', occupation: 'job', employer: 'work place')
+        person: person, occupation: 'job', employer: 'work place')
 
       donation.process
 
@@ -70,9 +69,11 @@ describe Donation do
     end
   end
 
-  def stub_person_find_or_initialize_by
-    person = spy('person')
-    allow(Person).to receive(:find_or_initialize_by).and_return(person)
+  def stub_person
+    person = create(:person)
+    allow(person).to receive(:update)
+    allow(person).to receive(:create_action)
+    allow(person).to receive(:create_subscription)
     person
   end
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -13,6 +13,9 @@ describe Donation do
   describe "process" do
     it "creates subscription if recurring is true" do
       person = stub_person
+      allow(person).to receive(:update)
+      allow(person).to receive(:create_subscription)
+
       stub_stripe_customer_create(id: 'customer id',
                                   subscription_id: 'subscription id')
       donation = Donation.new(amount_in_cents: 400, stripe_token: 'test token',
@@ -70,10 +73,8 @@ describe Donation do
   end
 
   def stub_person
-    person = create(:person)
-    allow(person).to receive(:update)
+    person = build_stubbed(:person)
     allow(person).to receive(:create_action)
-    allow(person).to receive(:create_subscription)
     person
   end
 

--- a/spec/requests/v1/donations_spec.rb
+++ b/spec/requests/v1/donations_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "POST /donation" do
       allow(NbDonationCreateJob).to receive(:perform_later)
 
       post "/donations", amount_in_cents: 400, stripe_token: 'test token',
-        recurring: true, email: person.email, occupation: 'job',
+        recurring: true, person: {email: person.email}, occupation: 'job',
         employer: 'work place'
 
       expect(Stripe::Customer).to have_received(:create).
@@ -34,7 +34,7 @@ RSpec.describe "POST /donation" do
       allow(NbDonationCreateJob).to receive(:perform_later)
 
       post "/donations", amount_in_cents: 300, stripe_token: 'test token',
-        email: 'test@example.com', occupation: 'job', employer: 'work place'
+        person: {email: 'test@example.com'}, occupation: 'job', employer: 'work place'
 
       expect(Stripe::Charge).to have_received(:create).
         with(hash_including(amount: 300, source: 'test token',


### PR DESCRIPTION
We need to save more than just a donors email address.  This update allows donation create to accept all standard person params.

* donations#create now accepts person params
* Also, I'm standardizing our error responses to 'error' rather than
'errors'