### PR TITLE
PersonConstructor uses only class methods

### DIFF
--- a/app/controllers/v1/actions_controller.rb
+++ b/app/controllers/v1/actions_controller.rb
@@ -19,7 +19,7 @@ class V1::ActionsController < V1::BaseController
     # need to handle invalid person
     activity = Activity.find_or_create_by(template_id: activity_param)
     @person = if person_params.any? # temporary fix
-                PersonConstructor.new(person_params).build.tap(&:save)
+                PersonConstructor.build(person_params).tap(&:save)
               end
 
     action_attributes = {person: @person, activity: activity}.merge(action_params)

--- a/app/controllers/v1/base_controller.rb
+++ b/app/controllers/v1/base_controller.rb
@@ -25,7 +25,7 @@ class V1::BaseController < ApplicationController
 
   def create_person_and_action(default_template_id: nil)
     person_params = params.require(:person).permit(PersonConstructor.permitted_params)
-    person = PersonConstructor.new(person_params).build.tap(&:save) # temporary fix
+    person = PersonConstructor.build(person_params).tap(&:save) # temporary fix
 
     action_params = params.permit(:template_id, :utm_source, :utm_medium, :utm_campaign, :source_url)
     action_params[:template_id] ||= default_template_id

--- a/app/controllers/v1/donations_controller.rb
+++ b/app/controllers/v1/donations_controller.rb
@@ -15,7 +15,7 @@ class V1::DonationsController < V1::BaseController
   #  * utm_campaign - action utm_campaign
   #  * source_url - action source_url
   def create
-    person = PersonConstructor.new(person_params).build.tap(&:save) # temporary fix
+    person = PersonConstructor.build(person_params).tap(&:save) # temporary fix
     donation = Donation.new(donation_params.merge(person: person))
     if donation.process
       render json: { status: 'success' }

--- a/app/controllers/v1/events_controller.rb
+++ b/app/controllers/v1/events_controller.rb
@@ -9,7 +9,7 @@ class V1::EventsController < V1::BaseController
     person = create_person_and_action(default_template_id: Activity::DEFAULT_TEMPLATE_IDS[:rsvp])
 
     response, status = rescue_error_messages do |variable|
-      Integration::NationBuilder.create_person_and_rsvp(event_id: params[:event_id], person_attributes: person.attributes)
+      Integration::NationBuilder.create_person_and_rsvp(event_id: params[:event_id], person_attributes: person.attributes.symbolize_keys)
     end
     render json: response, status: status
   end

--- a/app/controllers/v1/google_forms_controller.rb
+++ b/app/controllers/v1/google_forms_controller.rb
@@ -12,7 +12,7 @@ class V1::GoogleFormsController < V1::BaseController
   #    Google's servers infer type.
   #    example: {javascript_skill_level: 'advanced', legislator_nominatoin: 'Jack Russel'}
   def create
-    person = PersonConstructor.new(person_params).build.tap(&:save) # temporary fix
+    person = PersonConstructor.build(person_params).tap(&:save) # temporary fix
     if google_form_data_params.values.any?(&:present?) || (person && person.valid?)
       GoogleFormsSubmitJob.perform_later(google_form_metadata_params[:form_id], google_form_mapped_data)
       submitted = true

--- a/app/controllers/v1/people_controller.rb
+++ b/app/controllers/v1/people_controller.rb
@@ -1,7 +1,7 @@
 class V1::PeopleController < V1::BaseController
 
   def create
-    @person = PersonConstructor.new(person_params).build
+    @person = PersonConstructor.build(person_params)
     if @person.save
       if template_ids = params[:actions].presence
         @person.mark_activities_completed(template_ids)
@@ -19,7 +19,7 @@ class V1::PeopleController < V1::BaseController
   end
 
   def targets
-    @person = PersonConstructor.new(person_params).build.tap(&:save) # temporary fix
+    @person = PersonConstructor.build(person_params).tap(&:save) # temporary fix
     if @person.valid?
       render
     else

--- a/spec/controllers/v1/events_controller_spec.rb
+++ b/spec/controllers/v1/events_controller_spec.rb
@@ -21,8 +21,7 @@ describe V1::EventsController,  type: :controller do
         @activity = FactoryGirl.create(:activity, template_id: Activity::DEFAULT_TEMPLATE_IDS[:rsvp])
         @person = FactoryGirl.build(:person)
         allow(@person).to receive(:create_action)
-        constructor = double('constructor', build: @person)
-        allow(PersonConstructor).to receive(:new).and_return(constructor)
+        allow(PersonConstructor).to receive(:build).and_return(@person)
       end
 
       it "returns success" do
@@ -59,7 +58,8 @@ describe V1::EventsController,  type: :controller do
           person: person_params
         }
 
-        expect(PersonConstructor).to have_received(:new)
+        expect(Integration::NationBuilder).to have_received(:create_person_and_rsvp).
+          with(event_id: '5', person_attributes: @person.attributes.symbolize_keys)
       end
     end
     context "with missing person parameters" do

--- a/spec/controllers/v1/google_forms_controller_spec.rb
+++ b/spec/controllers/v1/google_forms_controller_spec.rb
@@ -6,8 +6,7 @@ describe V1::GoogleFormsController,  type: :controller do
     before do
       person = double('person', save: true)
       allow(person).to receive(:valid?).and_return(true)
-      constructor = double('constructor', build: person)
-      allow(PersonConstructor).to receive(:new).and_return(constructor)
+      allow(PersonConstructor).to receive(:build).and_return(person)
       allow(GoogleFormsSubmitJob).to receive(:perform_later)
 
       @google_form_submission_data = {attribute_one: 'first_attribute', attribute_two: 'second_attribute'}
@@ -27,7 +26,7 @@ describe V1::GoogleFormsController,  type: :controller do
           google_form_metadata: @google_form_metadata,
           google_form_submission_data: @google_form_submission_data
 
-        expect(PersonConstructor).to have_received(:new).with(email: fake_email)
+        expect(PersonConstructor).to have_received(:build).with(email: fake_email)
         expect(GoogleFormsSubmitJob).to have_received(:perform_later).with(
           @google_form_metadata[:form_id],
           {

--- a/spec/controllers/v1/ivr/calls_controller_spec.rb
+++ b/spec/controllers/v1/ivr/calls_controller_spec.rb
@@ -12,8 +12,7 @@ describe V1::Ivr::CallsController,  type: :controller do
       allow(@person).to receive(:create_action)
       allow(@person).to receive_message_chain(:calls, :create).and_return(call)
       allow(@person).to receive_message_chain(:phone).and_return(@target_phone)
-      constructor = double('constructor', build: @person)
-      allow(PersonConstructor).to receive(:new).and_return(constructor)
+      allow(PersonConstructor).to receive(:build).and_return(@person)
 
       twilio_call = double('twilio_call')
       allow(twilio_call).to receive(:sid).and_return(@fake_sid)

--- a/spec/services/person_constructor_spec.rb
+++ b/spec/services/person_constructor_spec.rb
@@ -6,7 +6,7 @@ describe PersonConstructor do
       params = { email: 'email' }
       stub_person_finder(params)
 
-      new_person = PersonConstructor.new(params).build
+      new_person = PersonConstructor.build(params)
 
       expect(new_person).to be_a PersonWithRemoteFields
     end
@@ -15,7 +15,7 @@ describe PersonConstructor do
       params = { email: 'email' }
       found_person = stub_person_finder(params)
 
-      new_person = PersonConstructor.new(params).build
+      new_person = PersonConstructor.build(params)
 
       expect(new_person.id).to eq found_person.id
     end
@@ -25,7 +25,7 @@ describe PersonConstructor do
       stub_person_finder(params, found: false)
       expected_person = stub_new_person_with_remote_fields
 
-      new_person = PersonConstructor.new(params).build
+      new_person = PersonConstructor.build(params)
 
       expect(new_person).to eq expected_person
     end
@@ -34,7 +34,7 @@ describe PersonConstructor do
       params = { first_name: 'name', occupation: 'work' }
       stub_person_finder(params)
 
-      person = PersonConstructor.new(params).build
+      person = PersonConstructor.build(params)
 
       expect(person.first_name).to eq 'name'
       expect(person.occupation).to eq 'work'
@@ -45,7 +45,7 @@ describe PersonConstructor do
       expected_params = { first_name: 'name', occupation: 'work' }
       stub_person_finder(expected_params)
 
-      person = PersonConstructor.new(params).build
+      person = PersonConstructor.build(params)
 
       expect(person.first_name).to eq 'name'
       expect(person.occupation).to eq 'work'
@@ -55,7 +55,7 @@ describe PersonConstructor do
       params = { city: 'city' }
       stub_person_finder(params)
 
-      person = PersonConstructor.new(params).build
+      person = PersonConstructor.build(params)
 
       expect(person.location.city).to eq 'city'
     end


### PR DESCRIPTION
Here's how PersonConstructor looks without instance methods. Personally, I think the internals of PersonConstructor were easier to deal with the other way, but the external interface is slightly better this way and tests are a little easier