### PR TITLE
fix failing specs (for seed 32446)

### DIFF
--- a/spec/models/action_spec.rb
+++ b/spec/models/action_spec.rb
@@ -22,7 +22,7 @@ describe Action do
   it { should validate_presence_of(:activity) }
 
   describe 'scopes' do
-    before(:all) do
+    before(:each) do
       @main_activity = FactoryGirl.create(:activity)
       FactoryGirl.create_list(:action, 3, activity: @main_activity)
       Timecop.freeze(4.days.ago) do


### PR DESCRIPTION
Specs were failing when using random order (e.g., with seed 32446).