### PR TITLE
make sure Person validates associated location

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -30,6 +30,8 @@ class Person < ActiveRecord::Base
   has_many :actions, dependent: :destroy
   has_many :activities, through: :actions
 
+  validates_associated :location
+
   validates :email, uniqueness: { case_sensitive: false },
     email_format: { message: 'is invalid' },
     allow_nil: true
@@ -46,9 +48,6 @@ class Person < ActiveRecord::Base
     .where('email = :identifier OR uuid = :identifier OR phone = :identifier', identifier: identifier)
   }
 
-  alias_method :location_association, :location
-  delegate :district, :state, to: :location
-
   DEFAULT_TARGET_COUNT = 100
   PERMITTED_PARAMS = [:email, :phone, :first_name, :last_name, :is_volunteer]
 
@@ -58,8 +57,8 @@ class Person < ActiveRecord::Base
     SecureRandom.uuid
   end
 
-  def location
-    location_association || build_location
+  def guaranteed_location
+    location || build_location
   end
 
   def mark_activities_completed(template_ids)

--- a/app/models/person_with_remote_fields.rb
+++ b/app/models/person_with_remote_fields.rb
@@ -7,12 +7,11 @@ class PersonWithRemoteFields < Person
 
   attr_accessor *REMOTE_FIELDS
 
-
   def save(args = {})
     if valid?
       update_remote
     end
-    super # will try to save location, but won't complain if it can't
+    super
   end
 
   def params_for_remote_update
@@ -61,7 +60,7 @@ class PersonWithRemoteFields < Person
   end
 
   def location_params
-    if (location.changed & Location::ADDRESS_FIELDS.map(&:to_s)).any?
+    if location && (location.changed & Location::ADDRESS_FIELDS.map(&:to_s)).any?
       location.as_json  # maybe dangerous to reuse serializable_hash here?
     else
       {}

--- a/app/services/person_constructor.rb
+++ b/app/services/person_constructor.rb
@@ -46,7 +46,7 @@ class PersonConstructor
   def assign_location_attributes(person)
     if location_params.any?
       new_location = LocationComparable.new(location_params)
-      person.location.becomes(LocationComparable).merge(new_location)
+      person.guaranteed_location.becomes(LocationComparable).merge(new_location)
       person.location.set_missing_attributes
     end
   end

--- a/app/views/v1/actions/_action.json.jbuilder
+++ b/app/views/v1/actions/_action.json.jbuilder
@@ -1,4 +1,4 @@
 json.(action, :id, :created_at, :strike_amount_in_cents)
 json.first_name action.person.first_name
 json.last_initial action.person.last_initial
-json.location action.person.location, :city, :state_abbrev
+json.location action.person.guaranteed_location, :city, :state_abbrev

--- a/app/views/v1/people/targets.jbuilder
+++ b/app/views/v1/people/targets.jbuilder
@@ -1,9 +1,9 @@
 # app/views/mc_chat/index.json.jbuilder
 
 json.(@person, :uuid, :first_name, :last_name, :is_volunteer)
-json.address @person.location.address_1
-json.state @person.location.state
-json.zip @person.location.zip_code
+json.address @person.location.try(:address_1)
+json.state @person.location.try(:state)
+json.zip @person.location.try(:zip_code)
 json.local_legislators  @person.legislators
 json.target_legislators @person.target_legislators(json: true)
 json.address_required   @person.address_required?

--- a/spec/models/person_with_remote_fields_spec.rb
+++ b/spec/models/person_with_remote_fields_spec.rb
@@ -40,7 +40,7 @@ describe PersonWithRemoteFields do
 
     it "includes location attributes" do
       person = PersonWithRemoteFields.new
-      person.location.zip_code = '01111'
+      person.guaranteed_location.zip_code = '01111'
 
       params = person.params_for_remote_update
 
@@ -59,7 +59,7 @@ describe PersonWithRemoteFields do
     it "converts state to string" do
       person = PersonWithRemoteFields.new
       state = create(:state)
-      person.location.state = state
+      person.guaranteed_location.state = state
 
       params = person.params_for_remote_update
 


### PR DESCRIPTION
@Rio517 I want to get rid of the code that made it impossible for `some_person.location` to return nil. (Accomplished with these lines on Person:
```
alias_method :location_association, :location
...
def location
  location_association || build_location
end
```
)

The main reason I'm doing this is so that `validates_associated :location` will work. But I'm also doing it because I think it was a (my) bad idea in the first place. It was convenient in many places, but it was also a little 'magical'. Now the association will behave normally.

I've set this to merge into the `jt-person-constructor` branch so you can see the changes. You can proceed with merging `jt-person-constructor` into master and then I'll redo this PR to merge into master after.