### PR TITLE
Make PersonWithRemoteFields#location_params less fragile

### DIFF
--- a/app/models/person_with_remote_fields.rb
+++ b/app/models/person_with_remote_fields.rb
@@ -61,7 +61,8 @@ class PersonWithRemoteFields < Person
 
   def location_params
     if location && (location.changed & Location::ADDRESS_FIELDS.map(&:to_s)).any?
-      location.as_json  # maybe dangerous to reuse serializable_hash here?
+      location.as_json(methods: [:state_abbrev],
+                       only: [:address_1, :address_2, :city, :zip_code])
     else
       {}
     end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -86,7 +86,7 @@ describe Location do
   end
 
   describe "#as_json" do
-    it "includes state_abbrev and not state" do
+    it "returns correct fields by default" do
       state = build(:state)
       location = Location.new(address_1: 'address', state: state)
 
@@ -96,6 +96,14 @@ describe Location do
         'address_1' => 'address', 'address_2' => nil, 'city' => nil,
         'state_abbrev' => state.abbrev, 'zip_code' => nil
       })
+    end
+
+    it "returns specified fields when called with args" do
+      location = Location.new(address_1: 'address', city: 'city')
+
+      json = location.as_json(only: [:city])
+
+      expect(json).to eq('city' => 'city')
     end
   end
 end

--- a/spec/models/person_with_remote_fields_spec.rb
+++ b/spec/models/person_with_remote_fields_spec.rb
@@ -20,22 +20,22 @@ describe PersonWithRemoteFields do
       expect(params).to eq({})
     end
 
-    it "always includes email or phone" do
-      person = PersonWithRemoteFields.new
+    it "always includes email if present" do
+      person = create(:person).becomes(PersonWithRemoteFields)
       person.first_name = 'name'
 
       params = person.params_for_remote_update
 
-      expect(params).to eq(phone: nil, first_name: 'name')
+      expect(params).to eq(email: person.email, first_name: 'name')
     end
 
-    it "includes remote attributes" do
-      person = PersonWithRemoteFields.new
-      person.employer = 'work'
+    it "includes phone if email not present" do
+      person = create(:person, email: nil).becomes(PersonWithRemoteFields)
+      person.first_name = 'name'
 
       params = person.params_for_remote_update
 
-      expect(params).to eq(phone: nil, employer: 'work')
+      expect(params).to eq(phone: person.phone, first_name: 'name')
     end
 
     it "includes location attributes" do
@@ -55,13 +55,22 @@ describe PersonWithRemoteFields do
       )
     end
 
+    it "includes remote attributes" do
+      person = PersonWithRemoteFields.new
+      person.employer = 'work'
+
+      params = person.params_for_remote_update
+
+      expect(params).to eq(phone: nil, employer: 'work')
+    end
+
     it "includes custom fields" do
       person = PersonWithRemoteFields.new
       person.custom_fields[:foo] = 'bar'
 
       params = person.params_for_remote_update
 
-      expect(params).to include(phone: nil, foo: 'bar')
+      expect(params).to eq(phone: nil, foo: 'bar')
     end
 
     it "symbolizes keys" do

--- a/spec/models/person_with_remote_fields_spec.rb
+++ b/spec/models/person_with_remote_fields_spec.rb
@@ -40,11 +40,19 @@ describe PersonWithRemoteFields do
 
     it "includes location attributes" do
       person = PersonWithRemoteFields.new
-      person.guaranteed_location.zip_code = '01111'
+      state = build(:state)
+      person.build_location(state: state, zip_code: '01111')
 
       params = person.params_for_remote_update
 
-      expect(params).to include(phone: nil, zip_code: '01111')
+      expect(params).to eq(
+        phone: nil,
+        address_1: nil,
+        address_2: nil,
+        city: nil,
+        state_abbrev: state.abbrev,
+        zip_code: '01111'
+      )
     end
 
     it "includes custom fields" do
@@ -54,16 +62,6 @@ describe PersonWithRemoteFields do
       params = person.params_for_remote_update
 
       expect(params).to include(phone: nil, foo: 'bar')
-    end
-
-    it "converts state to string" do
-      person = PersonWithRemoteFields.new
-      state = create(:state)
-      person.guaranteed_location.state = state
-
-      params = person.params_for_remote_update
-
-      expect(params).to include(phone: nil, state_abbrev: state.abbrev)
     end
 
     it "symbolizes keys" do


### PR DESCRIPTION
The goal here is to make sure that changing the `Location#serializable_hash` method won't break `PersonWithRemoteFields#location_params`.

I think the most important change here is the test that makes sure that location params are returned exactly as expected. I'm not sure that the change to `location_params` method is actually necessary.
