### PR TITLE
Only accept 5-digit zip codes

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -23,7 +23,7 @@ class Location < ActiveRecord::Base
   validates :state, presence: true, unless: :zip_code
   validates :zip_code, presence: true, unless: :state
   validates :zip_code, allow_nil: true,
-    format: { with: /\A\d{5}[^\w]?(\d{4})?\z/ }
+    format: { with: /\A\d{5}\z/ }
 
   ADDRESS_FIELDS = [
     :address_1, :address_2, :city, :state_id, :zip_code, :district_id
@@ -67,7 +67,7 @@ class Location < ActiveRecord::Base
   end
 
   def find_zip_code
-    @_find_zip_code ||= zip_code && ZipCode.find_by_zip(zip_code)
+    @_find_zip_code ||= zip_code && ZipCode.find_by(zip_code: zip_code)
   end
 
   def serializable_hash(options)

--- a/app/models/zip_code.rb
+++ b/app/models/zip_code.rb
@@ -25,14 +25,6 @@ class ZipCode < ActiveRecord::Base
   validates :zip_code, presence: true, uniqueness: { case_sensitive: false },
       format: { with: /\A\d{5}\z/ }
 
-  def self.valid_zip?(string)
-    /\A(?<zip>\d{5})[^\w]?(\d{4})?\z/ =~ string
-  end
-
-  def self.find_by_zip(zip)
-    find_by(zip_code: zip.first(5))
-  end
-
   def single_district?
     districts.size == 1
   end

--- a/app/services/person_constructor.rb
+++ b/app/services/person_constructor.rb
@@ -74,9 +74,7 @@ class PersonConstructor
   end
 
   def normalize_zip_code
-    if params[:zip_code]
-      params[:zip_code] = params[:zip_code].gsub!(/\A(\d{5})[^\w]?(\d{4})?\z/, '\1')
-    end
+    params[:zip_code].try(:gsub!, /\A(\d{5})[^\w]?(\d{4})\z/, '\1')
   end
 
   def person_params

--- a/app/services/person_constructor.rb
+++ b/app/services/person_constructor.rb
@@ -55,6 +55,7 @@ class PersonConstructor
     flatten_remote_fields
     normalize_keys
     strip_whitespace_from_values
+    normalize_zip_code
   end
 
   def flatten_remote_fields
@@ -70,6 +71,12 @@ class PersonConstructor
 
   def strip_whitespace_from_values
     params.merge!(params){ |k, v, _| v.try(:strip) || v }
+  end
+
+  def normalize_zip_code
+    if params[:zip_code]
+      params[:zip_code] = params[:zip_code].gsub!(/\A(\d{5})[^\w]?(\d{4})?\z/, '\1')
+    end
   end
 
   def person_params

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -29,10 +29,8 @@ describe Location do
     expect(Location.new(zip_code: '00001')).not_to validate_presence_of(:state)
   end
   describe "zip_code format" do
-    ['00000', '123456789', '11111-0000'].each do |valid_zip|
-      it { should allow_value(valid_zip).for(:zip_code) }
-    end
-    ['bad', '123456', '1234567890', '11111--0000'].each do |bad_zip|
+    it { should allow_value('12345').for(:zip_code) }
+    ['bad', '123456', '123456789', '11111-0000'].each do |bad_zip|
       it { should_not allow_value(bad_zip).for(:zip_code) }
     end
   end

--- a/spec/models/zip_code_spec.rb
+++ b/spec/models/zip_code_spec.rb
@@ -16,4 +16,52 @@
 require 'rails_helper'
 
 describe ZipCode do
+  describe "#single_district?" do
+    it "returns true if zip code has 1 district" do
+      zip = ZipCode.new
+      zip.districts << District.new
+
+      result = zip.single_district?
+
+      expect(result).to be true
+    end
+
+    it "returns false if zip code has no districts" do
+      zip = ZipCode.new
+
+      result = zip.single_district?
+
+      expect(result).to be false
+    end
+
+    it "returns false if zip code has multiple districts" do
+      zip = ZipCode.new
+      zip.districts << [District.new, District.new]
+
+      result = zip.single_district?
+
+      expect(result).to be false
+    end
+  end
+
+  describe "#single_district" do
+    it "returns district if zip code has 1 district" do
+      zip = ZipCode.new
+      district = District.new
+      zip.districts << district
+
+      result = zip.single_district
+
+      expect(result).to eq district
+    end
+
+    it "returns nil if zip code has multiple districts" do
+      zip = ZipCode.new
+      zip.districts << [District.new, District.new]
+
+      result = zip.single_district
+
+      expect(result).to be nil
+    end
+  end
 end

--- a/spec/models/zip_code_spec.rb
+++ b/spec/models/zip_code_spec.rb
@@ -16,28 +16,4 @@
 require 'rails_helper'
 
 describe ZipCode do
-
-  describe ".valid_zip_5" do
-    it "accepts valid zip codes" do
-      good_zips = %w[94703 950601234 05301-1234]
-      results = good_zips.select{|zip| ZipCode.valid_zip?(zip) }
-      expect(results).to eq %w[94703 950601234 05301-1234]
-    end
-
-    it "rejects bad zip codes" do
-      bad_zips = %w[1234 123456 12345-124]
-      results = bad_zips.select{|zip| ZipCode.valid_zip?(zip) }
-      expect(results).to eq []
-    end
-  end
-
-  describe ".find_by_zip" do
-    it "converts input to zip-5 and finds zip_code" do
-      allow(ZipCode).to receive(:find_by)
-
-      ZipCode.find_by_zip('111110000')
-
-      expect(ZipCode).to have_received(:find_by).with(zip_code: '11111')
-    end
-  end
 end

--- a/spec/services/person_constructor_spec.rb
+++ b/spec/services/person_constructor_spec.rb
@@ -70,14 +70,13 @@ describe PersonConstructor do
       expect(person.location.zip_code).to eq '12345'
     end
 
-    it "rejects bad zip codes" do
-      params = { zip_code: '1231' }
-      expected_params = { zip_code: nil }
-      stub_person_finder(expected_params)
+    it "passes bad zips through to the model" do
+      params = { zip_code: '123456' }
+      stub_person_finder(params, found: false)
 
-      person = PersonConstructor.build(params)
+      PersonConstructor.build(params)
 
-      expect(person.location.zip_code).to be nil
+      expect(PersonFinder).to have_received(:new).with(params)
     end
   end
 

--- a/spec/services/person_constructor_spec.rb
+++ b/spec/services/person_constructor_spec.rb
@@ -59,6 +59,26 @@ describe PersonConstructor do
 
       expect(person.location.city).to eq 'city'
     end
+
+    it "normalizes zip codes before assigning to location" do
+      params = { zip_code: '12345-0001' }
+      expected_params = { zip_code: '12345' }
+      stub_person_finder(expected_params)
+
+      person = PersonConstructor.build(params)
+
+      expect(person.location.zip_code).to eq '12345'
+    end
+
+    it "rejects bad zip codes" do
+      params = { zip_code: '1231' }
+      expected_params = { zip_code: nil }
+      stub_person_finder(expected_params)
+
+      person = PersonConstructor.build(params)
+
+      expect(person.location.zip_code).to be nil
+    end
   end
 
   def stub_person_finder(params, found: true)


### PR DESCRIPTION
This will make it easier to deal with address comparison. Location will now only accept 5 digit zips. PersonConstructor is responsible for making sure proper params are passed in.

I removed a couple methods from ZipCode, which caused me to remove all the specs, so I added some new specs to ZipCode for existing methods that previously had no tests.

Do we need to run an update query on production to make sure all stored zips are 5 digits?

I'm starting to feel like PersonConstructor is doing too much. I think we need a separate class to deal with person params (PersonParamsNormalizer?).
